### PR TITLE
Add engines_session_ids to workspace threads and update related API l…

### DIFF
--- a/server/prisma/migrations/20250722120730_added_engines_session_ids_to_threads/migration.sql
+++ b/server/prisma/migrations/20250722120730_added_engines_session_ids_to_threads/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspace_threads" ADD COLUMN "engines_session_ids" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -157,6 +157,7 @@ model workspace_threads {
   workspace_id  Int
   user_id       Int?
   user_pseudo_id String?
+  engines_session_ids String?
   createdAt     DateTime   @default(now())
   lastUpdatedAt DateTime   @default(now())
   workspace     workspaces @relation(fields: [workspace_id], references: [id], onDelete: Cascade)


### PR DESCRIPTION
…ogic

- Introduced engines_session_ids field in the workspace_threads model to store session data.
- Updated the WorkspaceThread.new method to accept engines_session_ids as a parameter.
- Modified API endpoint to handle engines_session_ids during thread creation and retrieval.
- Ensured proper JSON parsing for engines_session_ids when fetching threads from the database.


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
